### PR TITLE
Fix broken encodeRunestoneUnsafe function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,6 +90,7 @@ const u128Strict = (n: bigint) => {
   return u128(bigN);
 };
 
+// TODO: Add unit tests
 /**
  * Low level function to allow for encoding runestones without any indexer and transaction checks.
  *
@@ -147,7 +148,7 @@ export function encodeRunestoneUnsafe(runestone: RunestoneSpec): Buffer {
       : None;
     const symbol = etchingSpec.symbol ? Some(etchingSpec.symbol) : None;
 
-    if (divisibility.isSome() && divisibility.unwrap() < MAX_DIVISIBILITY) {
+    if (divisibility.isSome() && divisibility.unwrap() > MAX_DIVISIBILITY) {
       throw Error(`Divisibility is greater than protocol max ${MAX_DIVISIBILITY}`);
     }
 


### PR DESCRIPTION
- Add todo to unit test the exposed encoding function
- Fix divisibility conditional, currently broken

The `encodeRunestoneUnsafe` is important in itself because while `unsafe` for real time data, it does a job in testing stuff like divisibility, among other conditionals. It can be used, in the future, to test also, by receiving current block, if the rune name is available.

It makes me think tho if rather than giving maintenance to `encodeRunestoneUnsafe` if it isnt better to just expose through the library Rune and SpacedRune, and then test the stuff currently being tested on `encodeRunestoneUnsafe` inside the contructor of Rune and SpacedRune. This way, you can remove the complexity of having `encodeRunestoneUnsafe`, and can rely completely on unit tests of the classes.

DX might suffer a bit, but then again you can just provide some examples in the readme on how to construct a rune from `Rune` or `SpacedRune` classes