### PR TITLE
Feat: Rework `encodeRunestoneUnsafe` logic to support SpacedRunes in a seamless manner; add support for returning commitment

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { None, Option, Some } from './src/monads';
 import { Rune } from './src/rune';
 import { RuneId } from './src/runeid';
 import { Runestone } from './src/runestone';
+import { SpacedRune } from './src/spacedrune';
 import { Terms } from './src/terms';
 
 export {
@@ -30,7 +31,6 @@ export { Network } from './src/network';
 export { Rune } from './src/rune';
 export { RuneId } from './src/runeid';
 export { Runestone } from './src/runestone';
-export { SpacedRune } from './src/spacedrune';
 export { Terms } from './src/terms';
 
 export {
@@ -137,7 +137,7 @@ export function encodeRunestoneUnsafe(runestone: RunestoneSpec): Buffer {
       etchingSpec.premine !== undefined ? Some(etchingSpec.premine).map(u128Strict) : None;
     const rune =
       etchingSpec.rune !== undefined
-        ? Some(etchingSpec.rune).map((rune) => Rune.fromString(rune))
+        ? Some(etchingSpec.rune).map((rune) => etchingSpec.spacers?.length ? SpacedRune.fromString(rune) : Rune.fromString(rune))
         : None;
     const spacers = etchingSpec.spacers
       ? Some(

--- a/index.ts
+++ b/index.ts
@@ -148,7 +148,7 @@ export function encodeRunestoneUnsafe(runestone: RunestoneSpec): {
       etchingSpec.divisibility !== undefined ? Some(etchingSpec.divisibility).map(u8Strict) : None;
     const premine =
       etchingSpec.premine !== undefined ? Some(etchingSpec.premine).map(u128Strict) : None;
-    const spacers = hasSpacers ? Some(u32Strict((rune as any as SpacedRune)?.spacers)) : None;
+    const spacers: Option<u32> = hasSpacers && runeSpacers ? Some(u32Strict(runeSpacers)) : None;
     const symbol = etchingSpec.symbol ? Some(etchingSpec.symbol) : None;
 
     if (divisibility.isSome() && divisibility.unwrap() > MAX_DIVISIBILITY) {

--- a/index.ts
+++ b/index.ts
@@ -102,7 +102,7 @@ const SPACERS = ['•', '.'];
  */
 export function encodeRunestoneUnsafe(runestone: RunestoneSpec): {
   encodedRune: Buffer;
-  etchingCommitment: string | undefined;
+  etchingCommitment: Buffer | undefined;
 } {
   const mint = runestone.mint
     ? Some(new RuneId(u64Strict(runestone.mint.block), u32Strict(runestone.mint.tx)))
@@ -188,7 +188,7 @@ export function encodeRunestoneUnsafe(runestone: RunestoneSpec): {
     const turbo = etchingSpec.turbo ?? false;
 
     etching = Some(new Etching(divisibility, rune, spacers, symbol, terms, premine, turbo));
-    etchingCommitment = parsedRawRune?.commitment;
+    etchingCommitment = (parsedRawRune as Rune)?.commitment;
   }
 
   return {

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ export { Edict } from './src/edict';
 export { Etching } from './src/etching';
 export { Network } from './src/network';
 export { Rune } from './src/rune';
+export { SpacedRune } from './src/spacedrune';
 export { RuneId } from './src/runeid';
 export { Runestone } from './src/runestone';
 export { Terms } from './src/terms';

--- a/index.ts
+++ b/index.ts
@@ -137,7 +137,9 @@ export function encodeRunestoneUnsafe(runestone: RunestoneSpec): Buffer {
       etchingSpec.premine !== undefined ? Some(etchingSpec.premine).map(u128Strict) : None;
     const rune =
       etchingSpec.rune !== undefined
-        ? Some(etchingSpec.rune).map((rune) => etchingSpec.spacers?.length ? SpacedRune.fromString(rune) : Rune.fromString(rune))
+        ? Some(etchingSpec.rune).map((rune) =>
+            etchingSpec.spacers?.length ? SpacedRune.fromString(rune).rune : Rune.fromString(rune)
+          )
         : None;
     const spacers = etchingSpec.spacers
       ? Some(

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -122,7 +122,6 @@ export type RuneEtchingSpec = {
   rune?: string;
   divisibility?: number;
   premine?: bigint;
-  spacers?: number[];
   symbol?: string;
   terms?: {
     cap?: bigint;


### PR DESCRIPTION
This PR aims to make the `encodeRunestoneUnsafe` a ready to use function for the purposes of encoding runes without extra real time validations; and fix the scenario that right now it can't compile spaced runes.

It does that by:
- Automatically identifying if rune name contains spacers (the ones in Ord codebase); if it does, then it constructs the rune using `SpacedRune.fromString()`, which returns the spacers.`spacers` is then attributed to the spacers variable; and rune to the `rune` variable
- In order for it to be a ready to use SDK, it change the function signature to 
```typescript
export function encodeRunestoneUnsafe(runestone: RunestoneSpec): {
  encodedRune: Buffer;
  etchingCommitment: Buffer | undefined;
}
```
, and gets the commitment of the Rune from the `parsedRawRune` variable.

Testnet tests are available here:
https://testnet.ordinals.com/rune/PROSTAGMA%E2%80%A2MALEVOSKY
https://testnet.ordinals.com/rune/MALEVOSKY
https://testnet.ordinals.com/rune/PROSTAGMAMALEVO



