### PR TITLE
Added more explicit checking of uint types and better artifact type check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import { isRunestone as isRunestoneArtifact } from './src/artifact';
 import { MAX_DIVISIBILITY } from './src/constants';
 import { Etching } from './src/etching';
 import { Flaw as FlawEnum } from './src/flaw';
@@ -244,7 +243,7 @@ export function tryDecodeRunestone(tx: RunestoneTx): RunestoneSpec | Cenotaph | 
   }
 
   const artifact = optionArtifact.unwrap();
-  if (isRunestoneArtifact(artifact)) {
+  if (artifact.type === 'runestone') {
     const runestone = artifact;
 
     const etching = () => runestone.etching.unwrap();

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -2,7 +2,3 @@ import { Cenotaph } from './cenotaph';
 import { Runestone } from './runestone';
 
 export type Artifact = Cenotaph | Runestone;
-
-export function isRunestone(artifact: Artifact): artifact is Runestone {
-  return !('flaws' in artifact);
-}

--- a/src/cenotaph.ts
+++ b/src/cenotaph.ts
@@ -4,6 +4,8 @@ import { Rune } from './rune';
 import { RuneId } from './runeid';
 
 export class Cenotaph {
+  readonly type = 'cenotaph';
+
   constructor(
     readonly flaws: Flaw[],
     readonly etching: Option<Rune> = None,

--- a/src/indexer/updater.ts
+++ b/src/indexer/updater.ts
@@ -1,4 +1,4 @@
-import { Artifact, isRunestone } from '../artifact';
+import { Artifact } from '../artifact';
 import {
   COMMIT_CONFIRMATIONS,
   OP_RETURN,
@@ -112,7 +112,7 @@ export class RuneUpdater implements RuneBlockIndex {
 
       const optionEtched = await this.etched(txIndex, tx, artifact);
 
-      if (isRunestone(artifact)) {
+      if (artifact.type === 'runestone') {
         const runestone = artifact;
 
         if (optionEtched.isSome()) {
@@ -206,7 +206,7 @@ export class RuneUpdater implements RuneBlockIndex {
       return balance;
     }
 
-    if (optionArtifact.isSome() && !isRunestone(optionArtifact.unwrap())) {
+    if (optionArtifact.isSome() && optionArtifact.unwrap().type === 'cenotaph') {
       for (const balance of unallocated.values()) {
         const currentBalance = getBurnedRuneBalance(balance.runeId);
         currentBalance.amount = u128.checkedAddThrow(
@@ -217,7 +217,7 @@ export class RuneUpdater implements RuneBlockIndex {
     } else {
       const pointer = optionArtifact
         .map((artifact) => {
-          if (!isRunestone(artifact)) {
+          if (artifact.type === 'cenotaph') {
             throw new Error('unreachable');
           }
 
@@ -316,7 +316,7 @@ export class RuneUpdater implements RuneBlockIndex {
     artifact: Artifact
   ): Promise<Option<{ runeId: RuneLocation; rune: Rune }>> {
     let optionRune: Option<Rune>;
-    if (isRunestone(artifact)) {
+    if (artifact.type === 'runestone') {
       const runestone = artifact;
       if (runestone.etching.isNone()) {
         return None;
@@ -536,7 +536,7 @@ export class RuneUpdater implements RuneBlockIndex {
   }
 
   createEtching(txid: string, artifact: Artifact, runeId: RuneLocation, rune: Rune) {
-    if (isRunestone(artifact)) {
+    if (artifact.type === 'runestone') {
       const { divisibility, terms, premine, spacers, symbol } = artifact.etching.unwrap();
       this.etchings.push({
         valid: true,

--- a/src/integer/u128.ts
+++ b/src/integer/u128.ts
@@ -39,8 +39,17 @@ export const U128_MAX_BIGINT = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffffn;
  * @returns - The resulting 128-bit unsigned integer (BigInt).
  */
 export function u128(num: number | bigint): u128 {
-  const bigNum = typeof num == 'bigint' ? num : BigInt(num);
-  return (bigNum & U128_MAX_BIGINT) as u128;
+  if (typeof num == 'bigint') {
+    if (num < 0n || num > U128_MAX_BIGINT) {
+      throw new Error('num is out of range');
+    }
+  } else {
+    if (!Number.isSafeInteger(num) || num < 0) {
+      throw new Error('num is not a valid integer');
+    }
+  }
+
+  return BigInt(num) as u128;
 }
 
 export namespace u128 {

--- a/src/integer/u32.ts
+++ b/src/integer/u32.ts
@@ -22,8 +22,17 @@ export type u32 = BigTypedNumber<'u32'>;
 export const U32_MAX_BIGINT = 0xffff_ffffn;
 
 export function u32(num: number | bigint): u32 {
-  const bigNum = typeof num == 'bigint' ? num : BigInt(num);
-  return (bigNum & U32_MAX_BIGINT) as u32;
+  if (typeof num == 'bigint') {
+    if (num < 0n || num > U32_MAX_BIGINT) {
+      throw new Error('num is out of range');
+    }
+  } else {
+    if (!Number.isSafeInteger(num) || num < 0) {
+      throw new Error('num is not a valid integer');
+    }
+  }
+
+  return BigInt(num) as u32;
 }
 
 export namespace u32 {

--- a/src/integer/u64.ts
+++ b/src/integer/u64.ts
@@ -22,8 +22,17 @@ export type u64 = BigTypedNumber<'u64'>;
 export const U64_MAX_BIGINT = 0xffff_ffff_ffff_ffffn;
 
 export function u64(num: number | bigint): u64 {
-  const bigNum = typeof num == 'bigint' ? num : BigInt(num);
-  return (bigNum & U64_MAX_BIGINT) as u64;
+  if (typeof num == 'bigint') {
+    if (num < 0n || num > U64_MAX_BIGINT) {
+      throw new Error('num is out of range');
+    }
+  } else {
+    if (!Number.isSafeInteger(num) || num < 0) {
+      throw new Error('num is not a valid integer');
+    }
+  }
+
+  return BigInt(num) as u64;
 }
 
 export namespace u64 {

--- a/src/integer/u8.ts
+++ b/src/integer/u8.ts
@@ -22,8 +22,17 @@ export type u8 = BigTypedNumber<'u8'>;
 export const U8_MAX_BIGINT = 0xffn;
 
 export function u8(num: number | bigint): u8 {
-  const bigNum = typeof num == 'bigint' ? num : BigInt(num);
-  return (bigNum & U8_MAX_BIGINT) as u8;
+  if (typeof num == 'bigint') {
+    if (num < 0n || num > U8_MAX_BIGINT) {
+      throw new Error('num is out of range');
+    }
+  } else {
+    if (!Number.isSafeInteger(num) || num < 0) {
+      throw new Error('num is not a valid integer');
+    }
+  }
+
+  return BigInt(num) as u8;
 }
 
 export namespace u8 {

--- a/src/runestone.ts
+++ b/src/runestone.ts
@@ -26,6 +26,8 @@ export function isValidPayload(payload: Payload): payload is Buffer {
 }
 
 export class Runestone {
+  readonly type = 'runestone';
+
   constructor(
     readonly mint: Option<RuneId>,
     readonly pointer: Option<u32>,

--- a/test/runestone.test.ts
+++ b/test/runestone.test.ts
@@ -11,7 +11,7 @@ import { Edict } from '../src/edict';
 import { Etching } from '../src/etching';
 import { RuneId } from '../src/runeid';
 import { opcodes, script } from '../src/script';
-import { Artifact, isRunestone } from '../src/artifact';
+import { Artifact } from '../src/artifact';
 import { Flaw } from '../src/flaw';
 
 type RunestoneTx = { vout: { scriptPubKey: { hex: string } }[] };
@@ -123,7 +123,7 @@ describe('runestone', () => {
       ],
     }).unwrap();
 
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.OPCODE]);
@@ -172,7 +172,7 @@ describe('runestone', () => {
       [Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.BODY, 1, 1, 2, 0].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -191,7 +191,7 @@ describe('runestone', () => {
       [Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.RUNE, 4, Tag.BODY, 1, 1, 2, 0].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -210,7 +210,7 @@ describe('runestone', () => {
       [Tag.FLAGS, Flag.mask(Flag.TERMS), Tag.OFFSET_END, 4, Tag.BODY, 1, 1, 2, 0].map(u128)
     );
 
-    if (isRunestone(runestone)) {
+    if (runestone.type === 'runestone') {
       throw Error;
     }
 
@@ -233,7 +233,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -269,7 +269,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -295,7 +295,7 @@ describe('runestone', () => {
       getSimpleTransaction([opcodes.OP_RETURN, MAGIC_NUMBER, Buffer.from([128])])
     ).unwrap();
 
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
 
@@ -307,7 +307,7 @@ describe('runestone', () => {
       [Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.RUNE, 4, Tag.RUNE, 5, Tag.BODY, 1, 1, 2, 0].map(u128)
     );
 
-    if (isRunestone(runestone)) {
+    if (runestone.type === 'runestone') {
       throw Error;
     }
 
@@ -331,7 +331,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -342,7 +342,7 @@ describe('runestone', () => {
   test('runestone_with_unrecognized_even_tag_is_cenotaph', () => {
     const cenotaph = decipher([Tag.CENOTAPH, 0, Tag.BODY, 1, 1, 2, 0].map(u128));
 
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
 
@@ -354,7 +354,7 @@ describe('runestone', () => {
       [Tag.FLAGS, Flag.mask(Flag.CENOTAPH), Tag.BODY, 1, 1, 2, 0].map(u128)
     );
 
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
 
@@ -364,7 +364,7 @@ describe('runestone', () => {
   test('runestone_with_edict_id_with_zero_block_and_nonzero_tx_is_cenotaph', () => {
     const cenotaph = decipher([Tag.BODY, 0, 1, 2, 0].map(u128));
 
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
 
@@ -374,7 +374,7 @@ describe('runestone', () => {
   test('runestone_with_output_over_max_is_cenotaph', () => {
     const cenotaph = decipher([Tag.BODY, 1, 1, 2, 2].map(u128));
 
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
 
@@ -384,7 +384,7 @@ describe('runestone', () => {
   test('tag_with_no_value_is_cenotaph', () => {
     const runestone = decipher([Tag.FLAGS, 1, Tag.FLAGS].map(u128));
 
-    if (isRunestone(runestone)) {
+    if (runestone.type === 'runestone') {
       throw Error;
     }
 
@@ -397,12 +397,12 @@ describe('runestone', () => {
     for (const i of _.range(4)) {
       const runestone = decipher(integers.map(u128));
       if (i === 0) {
-        if (!isRunestone(runestone)) {
+        if (runestone.type === 'cenotaph') {
           throw Error;
         }
         expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
       } else {
-        expect(isRunestone(runestone)).toBe(false);
+        expect(runestone.type === 'runestone').toBe(false);
       }
 
       integers.push(0);
@@ -426,7 +426,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -456,7 +456,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -486,7 +486,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -506,7 +506,7 @@ describe('runestone', () => {
       )
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -554,7 +554,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -600,7 +600,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (isRunestone(runestone)) {
+    if (runestone.type === 'runestone') {
       throw Error;
     }
     expect(runestone.flaws).toEqual([Flaw.TRAILING_INTEGERS, Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -625,7 +625,7 @@ describe('runestone', () => {
       ].map(u128)
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -644,7 +644,7 @@ describe('runestone', () => {
       )
     );
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -655,7 +655,7 @@ describe('runestone', () => {
   test('runestone_may_contain_multiple_edicts', () => {
     const runestone = decipher([Tag.BODY, 1, 1, 2, 0, 0, 3, 5, 0].map(u128));
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -667,7 +667,7 @@ describe('runestone', () => {
 
   test('runestones_with_invalid_rune_id_blocks_are_cenotaph', () => {
     const cenotaph = decipher([Tag.BODY, 1, 1, 2, 0, u128.MAX, 1, 0, 0].map(u128));
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.EDICT_RUNE_ID]);
@@ -675,7 +675,7 @@ describe('runestone', () => {
 
   test('runestones_with_invalid_rune_id_txs_are_cenotaph', () => {
     const cenotaph = decipher([Tag.BODY, 1, 1, 2, 0, 1, u128.MAX, 0, 0].map(u128));
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.EDICT_RUNE_ID]);
@@ -698,7 +698,7 @@ describe('runestone', () => {
       ])
     ).unwrap();
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
 
@@ -727,7 +727,7 @@ describe('runestone', () => {
 
     const runestone = Runestone.decipher(transaction).unwrap();
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -753,7 +753,7 @@ describe('runestone', () => {
 
     const runestone = Runestone.decipher(transaction).unwrap();
 
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
     expect(runestone.edicts).toEqual([{ id: createRuneId(1), amount: 2n, output: 0n }]);
@@ -950,7 +950,7 @@ describe('runestone', () => {
         ].map(u128)
       );
 
-      if (isRunestone(runestone)) {
+      if (runestone.type === 'runestone') {
         throw Error;
       }
 
@@ -973,7 +973,7 @@ describe('runestone', () => {
 
       const txnRunestone = Runestone.decipher(transaction).unwrap();
 
-      if (!isRunestone(txnRunestone)) {
+      if (txnRunestone.type === 'cenotaph') {
         throw Error;
       }
 
@@ -1188,7 +1188,7 @@ describe('runestone', () => {
 
   test('edict_output_greater_than_32_max_produces_cenotaph', () => {
     const cenotaph = decipher([Tag.BODY, 1, 1, 1, u32.MAX + 1n].map(u128));
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.EDICT_OUTPUT]);
@@ -1196,7 +1196,7 @@ describe('runestone', () => {
 
   test('partial_mint_produces_cenotaph', () => {
     const cenotaph = decipher([Tag.MINT, 1].map(u128));
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -1204,7 +1204,7 @@ describe('runestone', () => {
 
   test('invalid_mint_produces_cenotaph', () => {
     const cenotaph = decipher([Tag.MINT, 0, Tag.MINT, 1].map(u128));
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -1212,7 +1212,7 @@ describe('runestone', () => {
 
   test('invalid_deadline_produces_cenotaph', () => {
     const cenotaph = decipher([Tag.OFFSET_END, u128.MAX].map(u128));
-    if (isRunestone(cenotaph)) {
+    if (cenotaph.type === 'runestone') {
       throw Error;
     }
     expect(cenotaph.flaws).toEqual([Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -1221,7 +1221,7 @@ describe('runestone', () => {
   test('invalid_pointer_produces_cenotaph', () => {
     {
       const cenotaph = decipher([Tag.POINTER, 1].map(u128));
-      if (isRunestone(cenotaph)) {
+      if (cenotaph.type === 'runestone') {
         throw Error;
       }
       expect(cenotaph.flaws).toEqual([Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -1229,7 +1229,7 @@ describe('runestone', () => {
 
     {
       const cenotaph = decipher([Tag.POINTER, u128.MAX].map(u128));
-      if (isRunestone(cenotaph)) {
+      if (cenotaph.type === 'runestone') {
         throw Error;
       }
       expect(cenotaph.flaws).toEqual([Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -1238,7 +1238,7 @@ describe('runestone', () => {
 
   test('invalid_divisibility_does_not_produce_cenotaph', () => {
     const runestone = decipher([Tag.DIVISIBILITY, u128.MAX].map(u128));
-    if (!isRunestone(runestone)) {
+    if (runestone.type === 'cenotaph') {
       throw Error;
     }
   });
@@ -1247,7 +1247,7 @@ describe('runestone', () => {
     {
       const runestone = decipher([Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.RUNE, 0].map(u128));
 
-      expect(isRunestone(runestone)).toEqual(true);
+      expect(runestone.type === 'runestone').toEqual(true);
     }
 
     {
@@ -1255,27 +1255,27 @@ describe('runestone', () => {
         [Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.RUNE, u128.MAX].map(u128)
       );
 
-      expect(isRunestone(runestone)).toEqual(true);
+      expect(runestone.type === 'runestone').toEqual(true);
     }
   });
 
   test('invalid_spacers_does_not_produce_cenotaph', () => {
     const runestone = decipher([Tag.SPACERS, u128.MAX].map(u128));
 
-    expect(isRunestone(runestone)).toEqual(true);
+    expect(runestone.type === 'runestone').toEqual(true);
   });
 
   test('invalid_symbol_does_not_produce_cenotaph', () => {
     const runestone = decipher([Tag.SYMBOL, u128.MAX].map(u128));
 
-    expect(isRunestone(runestone)).toEqual(true);
+    expect(runestone.type === 'runestone').toEqual(true);
   });
 
   test('invalid_term_produces_cenotaph', () => {
     const runestone = decipher([Tag.OFFSET_END, u128.MAX].map(u128));
 
-    expect(isRunestone(runestone)).toEqual(false);
-    if (isRunestone(runestone)) {
+    expect(runestone.type === 'runestone').toEqual(false);
+    if (runestone.type === 'runestone') {
       throw Error;
     }
     expect(runestone.flaws).toEqual([Flaw.UNRECOGNIZED_EVEN_TAG]);
@@ -1294,8 +1294,8 @@ describe('runestone', () => {
         ].map(u128)
       );
 
-      expect(isRunestone(runestone)).toBe(true);
-      if (!isRunestone(runestone)) {
+      expect(runestone.type === 'runestone').toBe(true);
+      if (runestone.type === 'cenotaph') {
         throw Error;
       }
     }
@@ -1311,7 +1311,7 @@ describe('runestone', () => {
           u128.MAX,
         ].map(u128)
       );
-      if (isRunestone(cenotaph)) {
+      if (cenotaph.type === 'runestone') {
         throw Error;
       }
       expect(cenotaph.flaws).toEqual([Flaw.SUPPLY_OVERFLOW]);
@@ -1328,7 +1328,7 @@ describe('runestone', () => {
           u128.MAX / 2n + 1n,
         ].map(u128)
       );
-      if (isRunestone(cenotaph)) {
+      if (cenotaph.type === 'runestone') {
         throw Error;
       }
       expect(cenotaph.flaws).toEqual([Flaw.SUPPLY_OVERFLOW]);
@@ -1347,7 +1347,7 @@ describe('runestone', () => {
           u128.MAX,
         ].map(u128)
       );
-      if (isRunestone(cenotaph)) {
+      if (cenotaph.type === 'runestone') {
         throw Error;
       }
       expect(cenotaph.flaws).toEqual([Flaw.SUPPLY_OVERFLOW]);
@@ -1375,7 +1375,7 @@ describe('runestone', () => {
       };
 
       const cenotaph = Runestone.decipher(transaction).unwrap();
-      if (isRunestone(cenotaph)) {
+      if (cenotaph.type === 'runestone') {
         throw Error;
       }
       expect(cenotaph.flaws).toEqual([Flaw.INVALID_SCRIPT]);
@@ -1409,12 +1409,10 @@ describe('runestone', () => {
 
       const scriptPubKey = Buffer.concat(scriptPubKeyBuffers);
       expect(
-        isRunestone(
-          Runestone.decipher({
-            vout: [{ scriptPubKey: { hex: scriptPubKey.toString('hex') } }],
-          }).unwrap()
-        )
-      ).toBe(true);
+        Runestone.decipher({
+          vout: [{ scriptPubKey: { hex: scriptPubKey.toString('hex') } }],
+        }).unwrap().type
+      ).toBe('runestone');
     }
   });
 
@@ -1424,23 +1422,19 @@ describe('runestone', () => {
         const opcode = opcodes.OP_RESERVED + i;
         const scriptPubKey = Buffer.from([OP_RETURN, MAGIC_NUMBER, 3, 0, 1, 0, opcode, 1, 0]);
         expect(
-          isRunestone(
-            Runestone.decipher({
-              vout: [{ scriptPubKey: { hex: scriptPubKey.toString('hex') } }],
-            }).unwrap()
-          )
-        ).toBe(false);
+          Runestone.decipher({
+            vout: [{ scriptPubKey: { hex: scriptPubKey.toString('hex') } }],
+          }).unwrap().type
+        ).toBe('cenotaph');
       }
 
       {
         const scriptPubKey = Buffer.from([OP_RETURN, MAGIC_NUMBER, 3, 0, 1, 0, 1, i, 1, 0]);
         expect(
-          isRunestone(
-            Runestone.decipher({
-              vout: [{ scriptPubKey: { hex: scriptPubKey.toString('hex') } }],
-            }).unwrap()
-          )
-        ).toBe(true);
+          Runestone.decipher({
+            vout: [{ scriptPubKey: { hex: scriptPubKey.toString('hex') } }],
+          }).unwrap().type
+        ).toBe('runestone');
       }
     }
   });

--- a/test/u128.test.ts
+++ b/test/u128.test.ts
@@ -7,8 +7,8 @@ describe('u128 functions', () => {
     expect(u128(0)).toBe(0n);
     expect(u128(1)).toBe(1n);
     expect(u128(2n ** 128n - 1n)).toBe(340282366920938463463374607431768211455n);
-    expect(u128(2n ** 128n)).toBe(0n);
-    expect(u128(-1)).toBe(340282366920938463463374607431768211455n);
+    expect(() => u128(2n ** 128n)).toThrow();
+    expect(() => u128(-1)).toThrow();
     expect(() => u128(1.2)).toThrow();
   });
 


### PR DESCRIPTION
- Fixed uint types to only allow valid and supported values (bigints and safe integer numbers within range)
- Changed internal isRunestone check to use type property with `runestone` or `cenotaph` instead