### PR TITLE
fix: decipher reads TURBO flag from wrong variable, always reports turbo=true

### DIFF
--- a/src/runestone.ts
+++ b/src/runestone.ts
@@ -120,7 +120,7 @@ export class Runestone {
           const premine = Tag.take(Tag.PREMINE, fields, 1, ([value]) => Some(value));
 
           const turboResult = Flag.take(flags, Flag.TURBO);
-          const turbo = etchingResult.set;
+          const turbo = turboResult.set;
           flags = turboResult.flags;
 
           return Some(new Etching(divisibility, rune, spacers, symbol, terms, premine, turbo));

--- a/test/runestone.test.ts
+++ b/test/runestone.test.ts
@@ -186,6 +186,35 @@ describe('runestone', () => {
     expect(etching.terms.isNone()).toBe(true);
   });
 
+  test('decipher_etching_without_turbo', () => {
+    // ETCHING flag set, TURBO flag NOT set -> etching.turbo === false
+    // Mirrors ord's reference test runestone.rs#decipher_runestone (turbo: false).
+    const runestone = decipher(
+      [Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.BODY, 1, 1, 2, 0].map(u128)
+    );
+
+    if (runestone.type === 'cenotaph') {
+      throw Error;
+    }
+
+    const etching = runestone.etching.unwrap();
+    expect(etching.turbo).toBe(false);
+  });
+
+  test('decipher_etching_with_turbo', () => {
+    // ETCHING + TURBO flags both set -> etching.turbo === true
+    const runestone = decipher(
+      [Tag.FLAGS, Flag.mask(Flag.ETCHING) | Flag.mask(Flag.TURBO), Tag.BODY, 1, 1, 2, 0].map(u128)
+    );
+
+    if (runestone.type === 'cenotaph') {
+      throw Error;
+    }
+
+    const etching = runestone.etching.unwrap();
+    expect(etching.turbo).toBe(true);
+  });
+
   test('decipher_etching_with_rune', () => {
     const runestone = decipher(
       [Tag.FLAGS, Flag.mask(Flag.ETCHING), Tag.RUNE, 4, Tag.BODY, 1, 1, 2, 0].map(u128)


### PR DESCRIPTION
`Runestone.decipher` always reports `etching.turbo === true` for any etching, regardless of whether the TURBO flag bit was set on chain. The fix is one line.

## The bug

`src/runestone.ts`, line 123:

```ts
const turboResult = Flag.take(flags, Flag.TURBO);
const turbo = etchingResult.set;   // ← bug
flags = turboResult.flags;
```

This line lives inside the `etchingFlag ? (() => {...})() : None` lambda (line 65), which is only entered when `etchingResult.set === true`. So `turbo` resolves to `true` unconditionally on every etching.

The reference implementation in [ord (`crates/ordinals/src/runestone.rs:86`)](https://github.com/ordinals/ord/blob/master/crates/ordinals/src/runestone.rs#L86) does:

```rust
turbo: Flag::Turbo.take(&mut flags),
```

The TS port already computes `turboResult` correctly on line 122 — it just assigns the wrong variable.

## Direction of the bug

Decode-only. The encode side (line 188) correctly emits the TURBO bit from `etching.turbo`, so a runestone encoded with `turbo: false` lands on chain correctly. But decoding it back reads `turbo: true`. Round-trip is broken in the decode direction.

## Quick verification

Both runes were etched in block 840,000

| Rune | Etching tx | On-chain turbo | Before fix | After fix |
|---|---|---|---|---|
| [`Z•Z•Z•Z•Z•FEHU•Z•Z•Z•Z•Z`](https://ordinals.com/rune/Z%E2%80%A2Z%E2%80%A2Z%E2%80%A2Z%E2%80%A2Z%E2%80%A2FEHU%E2%80%A2Z%E2%80%A2Z%E2%80%A2Z%E2%80%A2Z%E2%80%A2Z) | `2bb85f4b00…7c69e` | `true`  | `true`  ✓ (coincidence) | `true`  ✓ |
| [`DOG•GO•TO•THE•MOON`](https://ordinals.com/rune/DOG%E2%80%A2GO%E2%80%A2TO%E2%80%A2THE%E2%80%A2MOON)       | `e79134080a…a1375` | `false` | `true`  ✗ | `false` ✓ |